### PR TITLE
removed getting work item link for performance and other code cleanup

### DIFF
--- a/azure-devops-extension-private.json
+++ b/azure-devops-extension-private.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "wiTimeReportTest",
     "publisher": "OneLuckiDev",
-    "version": "0.1.88",
+    "version": "0.1.90",
     "name": "Work Item Flow Efficiency - TEST",
     "description": "This will give you insights in to who is approving the Pull Requests for your repository.",
     "public": false,

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "wiTimeReport",
     "publisher": "OneLuckiDev",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "name": "Work Item Flow Efficiency",
     "description": "Get Insight on the time your cards stay in your board columns.",
     "public": true,

--- a/src/Common.scss
+++ b/src/Common.scss
@@ -57,7 +57,7 @@
 
 .selectionCard
 {
-    min-height: 85px;
+    min-height: 101px;
 }
 .list-example-row 
 {
@@ -68,7 +68,7 @@
 {    
     border-spacing: 10px;
     width: 100%;
-
+    min-height: 450px;
 }
 .listColumnCard{
     min-width:450px;

--- a/src/contributions/wiTime/WITableSetup.tsx
+++ b/src/contributions/wiTime/WITableSetup.tsx
@@ -14,7 +14,7 @@ export const workItemColumns = [
     id: "workItemID",
     name: "ID",
     readonly: true,
-    renderCell: RenderIDLink,
+    renderCell: renderSimpleCell,
     width: new ObservableValue(-8),
 },
 {
@@ -63,7 +63,7 @@ export function RenderIDLink(
     tableItem: workItemInterfaces.IWorkItemTableDisplay
 ): JSX.Element
 {
-    const {     workItemID,  workItemTitle, workItemLink, revNum,  boardColumn, boardColumnStartTime, timeInColumn} = tableItem;
+    const { workItemID,  workItemLink} = tableItem;
     return (
 
         <SimpleTableCell columnIndex={columnIndex} tableColumn={tableColumn} key={"col-" + columnIndex} contentClassName="fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden">


### PR DESCRIPTION
The Work Item link in the results table doesn't provide a huge benefit for the use of this extension, but the performance hit incurred by calling to get each work Item detail just for that link is just too much to justify leaving it there, so I'm removing it for now